### PR TITLE
Add Markstream Svelte to Markdown Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ _Display a control element to paginate_
 
 _Display parsed markdow source_
 
+- [![](https://img.shields.io/github/stars/Simon-He95/markstream-vue?label=⭐&logo=_&style=social)](https://github.com/Simon-He95/markstream-vue) [Simon-He95/markstream-vue](https://github.com/Simon-He95/markstream-vue) — Svelte 5 streaming Markdown renderer for AI chat with Mermaid, KaTeX, Monaco-powered code blocks, safe HTML, and SSR.
 
 
 ### Canvas


### PR DESCRIPTION
Hi! Thanks for maintaining this Svelte resource list.

This adds [Markstream Svelte](https://www.npmjs.com/package/markstream-svelte) to the existing **Markdown Viewer** section. It is an MIT-licensed Svelte 5 streaming Markdown renderer designed for AI chat and incomplete LLM output, with Mermaid, KaTeX, Monaco-powered code blocks, safe HTML, and SSR support.

Repository: https://github.com/Simon-He95/markstream-vue
Svelte demo: https://markstream-svelte.pages.dev/

I kept the entry to the repository’s existing one-line format. Thank you for considering it!